### PR TITLE
fix(media-keys): There is no shortcut to open ukui-search quickly.

### DIFF
--- a/data/org.ukui.SettingsDaemon.plugins.media-keys.gschema.xml.in
+++ b/data/org.ukui.SettingsDaemon.plugins.media-keys.gschema.xml.in
@@ -205,5 +205,10 @@
       <summary>Open the internet connectionr</summary>
       <description>Binding open the unm-connection-edito.</description>
     </key>
+    <key name="ukui-search" type="s">
+      <default>'&lt;Win&gt;s'</default>
+      <summary>Unflod Ukui Search</summary>
+      <description>Binding to unflod the ukui-search.</description>
+    </key>
   </schema>
 </schemalist>

--- a/plugins/media-keys/acme.h
+++ b/plugins/media-keys/acme.h
@@ -67,6 +67,7 @@ enum {
         WINDOWSWITCH_KEY_2,
         SYSTEM_MONITOR_KEY,
         CONNECTION_EDITOR_KEY,
+        GLOBAL_SEARCH_KEY,
         HANDLED_KEYS,
 };
 
@@ -117,6 +118,7 @@ static struct {
         { WINDOWSWITCH_KEY_2, "ukui-window-switch2", NULL, NULL},
         { SYSTEM_MONITOR_KEY, "ukui-system-monitor", NULL, NULL },
         { CONNECTION_EDITOR_KEY, "nm-connection-editor", NULL, NULL },
+        { GLOBAL_SEARCH_KEY, "ukui-search", NULL, NULL },
 };
 
 #endif /* __ACME_H__ */

--- a/plugins/media-keys/usd-media-keys-manager.c
+++ b/plugins/media-keys/usd-media-keys-manager.c
@@ -1161,7 +1161,13 @@ do_system_monitor_action (UsdMediaKeysManager *manager)
 static void
 do_connection_editor_action (UsdMediaKeysManager *manager)
 {
-         execute (manager, "nm-connection-editor",FALSE,FALSE);
+        execute (manager, "nm-connection-editor",FALSE,FALSE);
+}
+
+static void
+do_open_ukui_search_action(UsdMediaKeysManager *manager)
+{
+        execute (manager, "ukui-search -s",FALSE,FALSE);
 }
 
 static gboolean
@@ -1299,6 +1305,9 @@ do_action (UsdMediaKeysManager *manager,
                 break;
         case CONNECTION_EDITOR_KEY:
                 do_connection_editor_action (manager);
+                break;
+        case GLOBAL_SEARCH_KEY:
+                do_open_ukui_search_action (manager);
                 break;
         default:
                 g_assert_not_reached ();

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -650,6 +650,10 @@ msgstr "截取一个区域的截图"
 msgid "Binding to take a screenshot of an area."
 msgstr "截取一个区域的截图快捷键绑定。"
 
+#: ../data/org.ukui.SettingsDaemon.plugins.media-keys.gschema.xml.in.h:67
+msgid "Unflod Ukui Search"
+msgstr "显示全局搜索"
+
 #: ../data/org.ukui.SettingsDaemon.plugins.xrandr.gschema.xml.in.h:5
 msgid "Show Displays in Notification Area"
 msgstr "在通知区域显示"


### PR DESCRIPTION
Description: 修复没有全局搜索快捷键的bug
Log: 暂时添加全局搜索快捷键Win+s
Bug: http://172.17.66.192/biz/bug-view-33219.html